### PR TITLE
Implement job skeleton

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+## \ud83c\udf3f Project Overview
+This Laravel SaaS application is a **Cleaning Job Portal**. It is multi-tenant, meaning each office (company) can sign up, create jobs, and assign cleaners under their account.
+
+The app has 3 user roles:
+- **Super Admin** – Can manage all offices
+- **Office Admin** – Can create jobs, assign cleaners, monitor work
+- **Cleaner** – Views daily assigned jobs, updates status, uploads photos/videos
+
+---
+
+## \ud83c\udfbe Core Features
+
+### 1. Authentication & Roles
+- Tenancy support (Stancl/Laravel Tenancy)
+- Super Admin login (global)
+- Office registration/login (tenant)
+- Cleaners assigned to tenant
+
+### 2. Job Creation (Office Admin)
+- Create Job with:
+  - Job Title
+  - Plot Number
+  - Site Location
+  - Date & Time
+  - Job Type (Dropdown)
+  - Instructions (optional)
+- Assign one or more cleaners
+- Set status: Pending / In Progress / Completed / Not Ready / Partially Done
+
+### 3. Cleaner Dashboard
+- View assigned jobs by date (calendar and list view)
+- Filter by status
+- Mark job as:
+  - \u2705 Done
+  - \u274c Not Ready
+  - \u26a0\ufe0f Partially Done
+- Leave comments
+- Upload image/video proof
+- See job instructions
+
+### 4. Office Dashboard
+- View job completion stats
+- Track job progress per cleaner
+- Calendar view for all jobs
+- Job detail page with attachments/comments
+
+### 5. Super Admin Dashboard
+- List of offices
+- See total number of jobs
+- Monitor cleaner activity across tenants
+
+---
+
+## \ud83d\udceb Tech Suggestions
+- Laravel 11
+- Jetstream or Breeze for Auth
+- Spatie Roles & Permissions
+- Media uploads (Spatie MediaLibrary or native Laravel)
+- Livewire/Alpine or Vue for dynamic UI
+- FullCalendar.js for calendar views
+- Blade UI for lightweight UIs
+
+---
+
+## \u2705 Visual Layouts (Rough Sketchs)
+
+- `/dashboard` \u2192 Role-based (Cleaner vs Office)
+- `/jobs/create` \u2192 Form with cleaner assign dropdown
+- `/jobs/calendar` \u2192 Calendar with clickable job entries
+- `/cleaner/tasks/today` \u2192 Card list or timeline of jobs
+- `/jobs/{id}` \u2192 Detail view with updates, media, notes
+
+---
+
+## \ud83e\udde0 Notes
+- System should be API-ready for mobile later.
+- Ensure scalable architecture with policy controls.
+- Clean separation between tenant environments (DB separation or scoped by tenant_id).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
 
+## Cleaning Portal SaaS
+
+This application provides multi-tenant job management for cleaning companies. Offices can create jobs and assign cleaners who update progress from their dashboards.
+
 <p align="center">
 <a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>

--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Job;
+use Illuminate\Http\Request;
+
+class JobController extends Controller
+{
+    public function index()
+    {
+        $jobs = Job::latest()->paginate();
+        return view('jobs.index', compact('jobs'));
+    }
+
+    public function create()
+    {
+        return view('jobs.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'plot_number' => 'required|string',
+            'location' => 'required|string',
+            'job_type' => 'required|string',
+            'scheduled_at' => 'required|date',
+            'notes' => 'nullable|string',
+        ]);
+
+        $job = Job::create(array_merge($validated, [
+            'office_id' => auth()->id(),
+            'status' => 'pending',
+        ]));
+
+        return redirect()->route('jobs.show', $job);
+    }
+
+    public function show(Job $job)
+    {
+        return view('jobs.show', compact('job'));
+    }
+
+    public function edit(Job $job)
+    {
+        return view('jobs.edit', compact('job'));
+    }
+
+    public function update(Request $request, Job $job)
+    {
+        $validated = $request->validate([
+            'plot_number' => 'required|string',
+            'location' => 'required|string',
+            'job_type' => 'required|string',
+            'scheduled_at' => 'required|date',
+            'notes' => 'nullable|string',
+            'status' => 'required|string',
+        ]);
+
+        $job->update($validated);
+
+        return redirect()->route('jobs.show', $job);
+    }
+
+    public function destroy(Job $job)
+    {
+        $job->delete();
+        return redirect()->route('jobs.index');
+    }
+}

--- a/app/Models/Cleaner.php
+++ b/app/Models/Cleaner.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Cleaner extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['user_id', 'office_id'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function office()
+    {
+        return $this->belongsTo(Office::class);
+    }
+
+    public function jobs()
+    {
+        return $this->belongsToMany(Job::class);
+    }
+}

--- a/app/Models/Job.php
+++ b/app/Models/Job.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Job extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'office_id',
+        'plot_number',
+        'location',
+        'job_type',
+        'scheduled_at',
+        'notes',
+        'status',
+    ];
+
+    protected $casts = [
+        'scheduled_at' => 'datetime',
+    ];
+
+    public function office()
+    {
+        return $this->belongsTo(Office::class);
+    }
+
+    public function cleaners()
+    {
+        return $this->belongsToMany(Cleaner::class);
+    }
+}

--- a/app/Models/Office.php
+++ b/app/Models/Office.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Office extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function cleaners()
+    {
+        return $this->hasMany(Cleaner::class);
+    }
+
+    public function jobs()
+    {
+        return $this->hasMany(Job::class);
+    }
+}

--- a/database/migrations/0001_01_01_000003_create_offices_table.php
+++ b/database/migrations/0001_01_01_000003_create_offices_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('offices', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('offices');
+    }
+};

--- a/database/migrations/0001_01_01_000004_create_cleaners_table.php
+++ b/database/migrations/0001_01_01_000004_create_cleaners_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cleaners', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('office_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cleaners');
+    }
+};

--- a/database/migrations/0001_01_01_000005_create_cleaning_jobs_table.php
+++ b/database/migrations/0001_01_01_000005_create_cleaning_jobs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cleaning_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('office_id')->constrained()->cascadeOnDelete();
+            $table->string('plot_number');
+            $table->string('location');
+            $table->string('job_type');
+            $table->timestamp('scheduled_at');
+            $table->text('notes')->nullable();
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cleaning_jobs');
+    }
+};

--- a/database/migrations/0001_01_01_000006_create_cleaner_job_table.php
+++ b/database/migrations/0001_01_01_000006_create_cleaner_job_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cleaner_job', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('job_id')->constrained('cleaning_jobs')->cascadeOnDelete();
+            $table->foreignId('cleaner_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cleaner_job');
+    }
+};

--- a/resources/views/jobs/create.blade.php
+++ b/resources/views/jobs/create.blade.php
@@ -1,0 +1,10 @@
+<h1>Create Job</h1>
+<form method="POST" action="{{ route('jobs.store') }}">
+    @csrf
+    <input name="plot_number" placeholder="Plot Number">
+    <input name="location" placeholder="Location">
+    <input name="job_type" placeholder="Job Type">
+    <input type="datetime-local" name="scheduled_at">
+    <textarea name="notes" placeholder="Notes"></textarea>
+    <button type="submit">Save</button>
+</form>

--- a/resources/views/jobs/edit.blade.php
+++ b/resources/views/jobs/edit.blade.php
@@ -1,0 +1,12 @@
+<h1>Edit Job</h1>
+<form method="POST" action="{{ route('jobs.update', $job) }}">
+    @csrf
+    @method('PUT')
+    <input name="plot_number" value="{{ $job->plot_number }}" placeholder="Plot Number">
+    <input name="location" value="{{ $job->location }}" placeholder="Location">
+    <input name="job_type" value="{{ $job->job_type }}" placeholder="Job Type">
+    <input type="datetime-local" name="scheduled_at" value="{{ $job->scheduled_at->format('Y-m-d\TH:i') }}">
+    <textarea name="notes" placeholder="Notes">{{ $job->notes }}</textarea>
+    <input name="status" value="{{ $job->status }}" placeholder="Status">
+    <button type="submit">Save</button>
+</form>

--- a/resources/views/jobs/index.blade.php
+++ b/resources/views/jobs/index.blade.php
@@ -1,0 +1,4 @@
+<h1>Jobs</h1>
+@foreach($jobs as $job)
+    <div><a href="{{ route('jobs.show', $job) }}">{{ $job->plot_number }} - {{ $job->location }}</a></div>
+@endforeach

--- a/resources/views/jobs/show.blade.php
+++ b/resources/views/jobs/show.blade.php
@@ -1,0 +1,7 @@
+<h1>Job Detail</h1>
+<div>Plot: {{ $job->plot_number }}</div>
+<div>Location: {{ $job->location }}</div>
+<div>Type: {{ $job->job_type }}</div>
+<div>Scheduled: {{ $job->scheduled_at }}</div>
+<div>Status: {{ $job->status }}</div>
+<a href="{{ route('jobs.edit', $job) }}">Edit</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,3 +5,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+use App\Http\Controllers\JobController;
+
+Route::resource('jobs', JobController::class);


### PR DESCRIPTION
## Summary
- outline the Cleaning Portal SaaS in the README
- create migrations for offices, cleaners, cleaning jobs and pivot
- add Job, Cleaner, Office models
- scaffold JobController with basic CRUD
- add job web routes and stub views

## Testing
- `php artisan test --testsuite Feature --testsuite Unit` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412a44be3883248dc8f72b324c761c